### PR TITLE
feat: 增加Github Actions

### DIFF
--- a/.github/workflows/sync_douban.yaml
+++ b/.github/workflows/sync_douban.yaml
@@ -1,0 +1,39 @@
+name: sync_douban
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  USER_AGENT: ${{ secrets.USER_AGENT }}
+  USER_COOKIE: ${{ secrets.USER_COOKIE }}
+  DOUBAN_USER_ID: ${{ secrets.DOUBAN_USER_ID }}
+  DOUBAN_DAY: ${{ secrets.DOUBAN_DAY }}
+  NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+  NOTION_BOOKS_DB: ${{ secrets.NOTION_BOOKS_DB }}
+  NOTION_MUSIC_DB: ${{ secrets.NOTION_MUSIC_DB }}
+  NOTION_MOVIE_DB: ${{ secrets.NOTION_MOVIE_DB }}
+  NOTION_GAME_DB: ${{ secrets.NOTION_GAME_DB }}
+
+jobs:
+  sync_douban:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: create config
+        run: cp doc/config.yaml.simple doc/config.yaml
+      - name: install python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip' # caching pip dependencies
+      - name: install python requirements
+        run: pip install -r requirements.txt
+      - name: sync douban
+        if: env.USER_AGENT != null && env.DOUBAN_USER_ID != null && env.DOUBAN_DAY != null && env.NOTION_TOKEN != null && env.NOTION_BOOKS_DB != null && env.NOTION_MUSIC_DB != null && env.NOTION_MOVIE_DB != null && env.NOTION_GAME_DB != null
+        run: |
+          python3 run.py -m music -s all
+          python3 run.py -m book -s all
+          python3 run.py -m movie -s all
+          python3 run.py -m game -s all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@
 
 [Unreleased]
 ============
-`[v0.1.2-beta] <https://github.com/Qliangw/notion_sync_data/compare/v0.1.2-alpha...v0.1.2-beta>`_ - 2023-02-20
+`[v0.1.2] <https://github.com/Qliangw/notion_sync_data/compare/v0.1.2-beta...v0.1.2>`_ - 2023-02-20
 ========================
 - fix: 修复导入某些项目失败的问题 `[pr#20] <https://github.com/Qliangw/notion_sync_data/pull/20>`_
 - feat: 新增游戏库的支持
@@ -21,6 +21,9 @@
 
 .. tip::
     - 更新后请先运行 python run.py -f config
+
+`[v0.1.2-beta] <https://github.com/Qliangw/notion_sync_data/compare/v0.1.2-alpha...v0.1.2-beta>`_ - 2023-02-20
+========================
 
 `[v0.1.2-alpha] <https://github.com/Qliangw/notion_sync_data/compare/v0.1.1...v0.1.2-alpha>`_ - 2022-08-23
 ========================

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 
 
-**最新版本：**[v0.1.2-beta](https://github.com/Qliangw/notion_sync_data/releases/tag/v0.1.2-beta)
+**最新版本：**[v0.1.2](https://github.com/Qliangw/notion_sync_data/releases/tag/v0.1.2)
 
 ## 功能
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [x] 创建notion数据库
 - [x] 插入notion库
 - [x] 已添加的不再重复添加（根据豆瓣链接判断）
+- [x] Github Actions自动同步
 
 **TODO**
 

--- a/doc/config.yaml.simple
+++ b/doc/config.yaml.simple
@@ -16,7 +16,7 @@ app:
   log_server: 127.0.0.1:514
 
 # 【可选】 建议填写，以免触发触发豆瓣的反爬虫机制浏览器获取
-user_agent : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+user_agent : ''
 
 # 豆瓣参数
 douban:
@@ -24,7 +24,7 @@ douban:
   user_id: ''
 
   # 【必填】 1. 填写为0时，监控所有的  | 2. 填写非零的正整数，则监控x天内的。比如填写30，则监控一个月内的；365，则监控一年内的。
-  day: 3
+  day:
 
   # 【可选】从浏览器中获取
   # 填写后可解决某些导入失败的问题，但有被豆瓣封号的风险，请知悉

--- a/sync_data/app/sync.py
+++ b/sync_data/app/sync.py
@@ -4,6 +4,7 @@
 # @Function:
 
 import random
+from os import environ as env
 
 from sync_data.data.user_config import ConfigName, get_desensitization_of_user_info
 from sync_data.tool.douban import base
@@ -248,33 +249,33 @@ def start_sync(media_type, media_status):
     log_detail.info("【Config】读取用户配置的文件[config.yaml]")
 
     # 获取浏览器user-agent
-    user_agent = config_dict[ConfigName.USER_AGENT.value]
-    user_cookie = config_dict[ConfigName.DOUBAN.value][ConfigName.USER_COOKIE.value]
+    user_agent = config_dict[ConfigName.USER_AGENT.value] or env.get("USER_AGENT")
+    user_cookie = config_dict[ConfigName.DOUBAN.value][ConfigName.USER_COOKIE.value] or env.get("USER_COOKIE")
     log_detail.info(f"【Config】- 取得浏览器 user-agent：{user_agent}")
 
     # 获取豆瓣信息
-    user_id = config_dict[ConfigName.DOUBAN.value][ConfigName.DOUBAN_USER_ID.value]
+    user_id = config_dict[ConfigName.DOUBAN.value][ConfigName.DOUBAN_USER_ID.value] or env.get("DOUBAN_USER_ID")
     # 用户id脱敏处理
     x_user_id = get_desensitization_of_user_info(user_id)
     log_detail.info(f"【Config】- 取得用户 id：{x_user_id}")
-    monitoring_day = config_dict[ConfigName.DOUBAN.value][ConfigName.DOUBAN_DAY.value]
+    monitoring_day = config_dict[ConfigName.DOUBAN.value][ConfigName.DOUBAN_DAY.value] or int(env.get("DOUBAN_DAY"))
     log_detail.info(f"【Config】- 取得监控日期：{monitoring_day}")
 
     # 获取notion数据库的信息
-    token = config_dict[ConfigName.NOTION.value][ConfigName.NOTION_TOKEN.value]
+    token = config_dict[ConfigName.NOTION.value][ConfigName.NOTION_TOKEN.value] or env.get("NOTION_TOKEN")
     x_token = get_desensitization_of_user_info(token)
     log_detail.info(f"【Config】- 取得 notion 的 token：{x_token}")
 
     # auto_config = Config().get_config()
     database_id = ''
     if media_type == MediaType.BOOK.value:
-        database_id = config_dict['notion'][ConfigName.NOTION_BOOK.value]
+        database_id = config_dict['notion'][ConfigName.NOTION_BOOK.value] or env.get("NOTION_BOOKS_DB")
     elif media_type == MediaType.MUSIC.value:
-        database_id = config_dict['notion'][ConfigName.NOTION_MUSIC.value]
+        database_id = config_dict['notion'][ConfigName.NOTION_MUSIC.value] or env.get("NOTION_MUSIC_DB")
     elif media_type == MediaType.MOVIE.value:
-        database_id = config_dict['notion'][ConfigName.NOTION_MOVIE.value]
+        database_id = config_dict['notion'][ConfigName.NOTION_MOVIE.value] or env.get("NOTION_MOVIE_DB")
     elif media_type == MediaType.GAME.value:
-        database_id = config_dict['notion'][ConfigName.NOTION_GAME.value]
+        database_id = config_dict['notion'][ConfigName.NOTION_GAME.value] or env.get("NOTION_GAME_DB")
     try:
         if database_id is None:
             log_detail.info(f"【Config】配置文件缺少重要参数")

--- a/sync_data/version.py
+++ b/sync_data/version.py
@@ -1,1 +1,1 @@
-version = "0.1.2-beta"
+version = "0.1.2"


### PR DESCRIPTION
# 功能
可以使用Github Actions进行自动同步，详细文档参考https://docs.github.com/en/actions
# 使用方式
1. 运行初始化`python run.py -f init`。
2. Fork本仓库。
3. 在自己的仓库中创建`secretes `<img width="1401" alt="image" src="https://user-images.githubusercontent.com/28230530/224215688-63214f41-cf2c-4eb0-a225-ecf4623c3243.png"><img width="1113" alt="image" src="https://user-images.githubusercontent.com/28230530/224215932-da04ed3d-9591-4ac1-ab21-d0096037535f.png">
- `DOUBAN_DAY` 必填，需要监控的时间范围。工作流设置的时间是每天0点执行`0 0 * * *`，可自行修改。
- `USER_AGENT` 必填，建议填写，以免触发触发豆瓣的反爬虫机制浏览器获取。
- `DOUBAN_USER_ID` 必填。
- `NOTION_TOKEN` 必填。
- `NOTION_BOOKS_DB` 必填。
- `NOTION_MUSIC_DB` 必填。
- `NOTION_MOVIE_DB` 必填。
- `NOTION_GAME_DB` 必填。
- `USER_COOKIE` 选填，填写后可解决某些导入失败的问题，但有被豆瓣封号的风险，请知悉。
4. 可通过Actions查看运行状态。<img width="1643" alt="image" src="https://user-images.githubusercontent.com/28230530/224217168-74cc7057-3ece-4704-8a32-a236d6266fc2.png">

